### PR TITLE
Start SimpleCov with rails configuration?

### DIFF
--- a/lib/parliament/utils/test_helpers/simplecov_helper.rb
+++ b/lib/parliament/utils/test_helpers/simplecov_helper.rb
@@ -9,10 +9,11 @@ module Parliament
           SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter.new([
             Coveralls::SimpleCov::Formatter,
             SimpleCov::Formatter::HTMLFormatter
-            ])
-            SimpleCov.start
-          end
+          ])
+          profile = defined?(Rails) ? 'rails' : nil
+          SimpleCov.start profile
         end
       end
     end
   end
+end

--- a/lib/parliament/utils/version.rb
+++ b/lib/parliament/utils/version.rb
@@ -1,5 +1,5 @@
 module Parliament
   module Utils
-    VERSION = '0.7.2'.freeze
+    VERSION = '0.7.3'.freeze
   end
 end


### PR DESCRIPTION
I noticed that the SimpleCov coverage reports generated for apps like parliament.uk-things don't split out the files by type, this change starts SimpleCov with the rails pre-configuration option.

Not sure if this was deliberately avoided because this gem is also used for non-rails projects?

_Example of **parliament.uk-things** after update:_
![image](https://user-images.githubusercontent.com/498011/38028649-77cb0bd2-328b-11e8-83ac-a6b9c66e350a.png)
