### PR TITLE
[REFACTORING] Escape HTML for parliamentlive video urls

### DIFF
--- a/lib/parliament/utils/services/markdown_converter.rb
+++ b/lib/parliament/utils/services/markdown_converter.rb
@@ -36,15 +36,13 @@ module Parliament
             # Add video ID
             url << "/#{uri.path.split('/').last}?"
             # Add original query if present, and not an empty string
-            url << "#{uri.query}&" if uri.query&.size
+            url << "#{CGI.escapeHTML(uri.query).split(';amp;').join(';')}&amp;" if uri.query&.size
             # Add player options
             url << 'audioOnly=False&amp;autoStart=False&amp;statsEnabled=False'
           end
 
           # Return the video player
-          %(<div class="video-wrap">
-<iframe src="#{video_url}" name="UKPPlayer" title="UK Parliament Player" seamless="seamless" frameborder="0" allowfullscreen style="width: 100%; height: 100%"></iframe>
-</div>)
+          %(<div class="video-wrap"><iframe src="#{video_url}" name="UKPPlayer" title="UK Parliament Player" seamless="seamless" frameborder="0" allowfullscreen style="width: 100%; height: 100%"></iframe></div>)
         end
       end
     end

--- a/spec/parliament/utils/helpers/markdown_helper_spec.rb
+++ b/spec/parliament/utils/helpers/markdown_helper_spec.rb
@@ -19,10 +19,7 @@ RSpec.describe Parliament::Utils::Helpers::MarkdownHelper do
           video_url = 'https://parliamentlive.tv/event/index/1b5736b4-7c93-4827-a02f-abbf0bb36cc8?in=10:00:00&out=12:00:00'
           text = "You can include a video in your markdown #{video_url}"
           expect(subject.markdown(text)).to eq(
-            %(<p>You can include a video in your markdown </p><div class="video-wrap">
-<iframe src="https://videoplayback.parliamentlive.tv/Player/Index/1b5736b4-7c93-4827-a02f-abbf0bb36cc8?in=10:00:00&amp;out=12:00:00&amp;audioOnly=False&amp;autoStart=False&amp;statsEnabled=False" name="UKPPlayer" title="UK Parliament Player" seamless="seamless" frameborder="0" allowfullscreen style="width: 100%;height: 100%;"></iframe>
-</div>
-)
+            "<p>You can include a video in your markdown </p><div class=\"video-wrap\"><iframe src=\"https://videoplayback.parliamentlive.tv/Player/Index/1b5736b4-7c93-4827-a02f-abbf0bb36cc8?in=10:00:00&amp;out=12:00:00&amp;audioOnly=False&amp;autoStart=False&amp;statsEnabled=False\" name=\"UKPPlayer\" title=\"UK Parliament Player\" seamless=\"seamless\" frameborder=\"0\" allowfullscreen style=\"width: 100%;height: 100%;\"></iframe></div>\n"
           )
         end
       end

--- a/spec/parliament/utils/services/markdown_converter_spec.rb
+++ b/spec/parliament/utils/services/markdown_converter_spec.rb
@@ -9,9 +9,7 @@ RSpec.describe Parliament::Utils::Services::ParliamentMarkdownRenderer do
         context 'with start and end time' do
           it 'returns iframe HTML string replacement' do
             expect(parliament_markdown_renderer.send(:parliament_live_video_embed, 'https://parliamentlive.tv/event/index/1b5736b4-7c93-4827-a02f-abbf0bb36cc8?in=10:00:00&out=12:00:00')).to eq(
-        %(<div class="video-wrap">
-<iframe src="https://videoplayback.parliamentlive.tv/Player/Index/1b5736b4-7c93-4827-a02f-abbf0bb36cc8?in=10:00:00&out=12:00:00&audioOnly=False&amp;autoStart=False&amp;statsEnabled=False" name="UKPPlayer" title="UK Parliament Player" seamless="seamless" frameborder="0" allowfullscreen style="width: 100%; height: 100%"></iframe>
-</div>)
+              "<div class=\"video-wrap\"><iframe src=\"https://videoplayback.parliamentlive.tv/Player/Index/1b5736b4-7c93-4827-a02f-abbf0bb36cc8?in=10:00:00&amp;out=12:00:00&amp;audioOnly=False&amp;autoStart=False&amp;statsEnabled=False\" name=\"UKPPlayer\" title=\"UK Parliament Player\" seamless=\"seamless\" frameborder=\"0\" allowfullscreen style=\"width: 100%; height: 100%\"></iframe></div>"
             )
           end
         end
@@ -19,9 +17,7 @@ RSpec.describe Parliament::Utils::Services::ParliamentMarkdownRenderer do
         context 'with no start or end time' do
           it 'returns iframe HTML string replacement' do
             expect(parliament_markdown_renderer.send(:parliament_live_video_embed, 'https://parliamentlive.tv/event/index/1b5736b4-7c93-4827-a02f-abbf0bb36cc8')).to eq(
-        %(<div class="video-wrap">
-<iframe src="https://videoplayback.parliamentlive.tv/Player/Index/1b5736b4-7c93-4827-a02f-abbf0bb36cc8?audioOnly=False&amp;autoStart=False&amp;statsEnabled=False" name="UKPPlayer" title="UK Parliament Player" seamless="seamless" frameborder="0" allowfullscreen style="width: 100%; height: 100%"></iframe>
-</div>)
+              "<div class=\"video-wrap\"><iframe src=\"https://videoplayback.parliamentlive.tv/Player/Index/1b5736b4-7c93-4827-a02f-abbf0bb36cc8?audioOnly=False&amp;autoStart=False&amp;statsEnabled=False\" name=\"UKPPlayer\" title=\"UK Parliament Player\" seamless=\"seamless\" frameborder=\"0\" allowfullscreen style=\"width: 100%; height: 100%\"></iframe></div>"
             )
           end
         end


### PR DESCRIPTION
This fixes the problem where parliamentlive.tv videos were not loading into our iframes; the urls were using unescaped HTML `&` symbols in their query strings, where instead it should be the escaped HTML `&amp;`.