### PR TITLE
[Fix] Amend markdown sanitisation and rendering

### DIFF
--- a/lib/parliament/utils/helpers/markdown_helper.rb
+++ b/lib/parliament/utils/helpers/markdown_helper.rb
@@ -16,10 +16,8 @@ module Parliament
           parliament_scrubber = Parliament::Utils::Services::ParliamentMarkdownScrubber.new
 
           markdown = Redcarpet::Markdown.new(parliament_renderer, tables: true, autolink: true, lax_spacing: true)
-
-          html = markdown.render(template)
-          ActionController::Base.helpers.sanitize(html, scrubber: parliament_scrubber).html_safe
-          html.html_safe
+          sanitized_template = ActionController::Base.helpers.sanitize(template, scrubber: parliament_scrubber)
+          markdown.render(sanitized_template).html_safe
         end
       end
     end

--- a/lib/parliament/utils/services/markdown_converter.rb
+++ b/lib/parliament/utils/services/markdown_converter.rb
@@ -36,7 +36,7 @@ module Parliament
             # Add video ID
             url << "/#{uri.path.split('/').last}?"
             # Add original query if present, and not an empty string
-            url << "#{uri.query}&" if uri.query&.size
+            url << "#{CGI.unescapeHTML(uri.query)}&" if uri.query&.size
             # Add player options
             url << 'audioOnly=False&autoStart=False&statsEnabled=False'
           end

--- a/lib/parliament/utils/version.rb
+++ b/lib/parliament/utils/version.rb
@@ -1,5 +1,5 @@
 module Parliament
   module Utils
-    VERSION = '0.8.6'.freeze
+    VERSION = '0.8.7'.freeze
   end
 end


### PR DESCRIPTION
* Update ParliamentMarkdownRenderer to unescape uri query
* Update MarkdownHelper to first sanitise markdown, then replace links
* Update version number to 0.8.7